### PR TITLE
Add changes to fix colocated template sourcemaps

### DIFF
--- a/lib/colocated-broccoli-plugin.js
+++ b/lib/colocated-broccoli-plugin.js
@@ -102,18 +102,22 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
       let hasBackingClass = false;
       let hasTemplate = this.inputHasFile(basePath + '.hbs');
       let backingClassPath = basePath;
-
+      let ext;
       if (this.inputHasFile(basePath + '.js')) {
         backingClassPath += '.js';
+        ext = '.js';
         hasBackingClass = true;
       } else if (this.inputHasFile(basePath + '.ts')) {
         backingClassPath += '.ts';
+        ext = '.ts';
         hasBackingClass = true;
       } else if (this.inputHasFile(basePath + '.coffee')) {
         backingClassPath += '.coffee';
+        ext = '.coffee';
         hasBackingClass = true;
       } else {
         backingClassPath += '.js';
+        ext = '.js';
         hasBackingClass = false;
       }
 
@@ -173,9 +177,10 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
 
         // It's not clear to me how to format this correctly for coffeescript.
         if (!backingClassPath.endsWith('.coffee')) {
+          let file = filePathParts.name + ext;
           let jsContentsMap = jsContentsMagic.generateMap({
-            source: jsOutputPath,
-            file: jsOutputPath,
+            source: backingClassPath,
+            file,
             includeContent: true,
             hires: true
           });

--- a/lib/colocated-broccoli-plugin.js
+++ b/lib/colocated-broccoli-plugin.js
@@ -177,6 +177,7 @@ module.exports = class ColocatedTemplateProcessor extends Plugin {
             source: jsOutputPath,
             file: jsOutputPath,
             includeContent: true,
+            hires: true
           });
 
           jsContents += `\n//# sourceMappingURL=${jsContentsMap.toUrl()}`;


### PR DESCRIPTION
Adds `hires` parameter to include column info in sourcemaps and fixes relative paths for (nested) components, as discussed here: https://github.com/ember-cli/ember-cli-htmlbars/pull/763

